### PR TITLE
Fix extra spaces inserted into multi-line strings

### DIFF
--- a/src/Generator/AbstractTypeGenerator.php
+++ b/src/Generator/AbstractTypeGenerator.php
@@ -145,6 +145,22 @@ EOF;
             case is_object($var):
                 return $default;
 
+            case is_string($var):
+                $string = var_export($var, true);
+
+                // handle multi-line strings
+                $lines = explode("\n", $string);
+                if (count($lines) > 1) {
+                    $firstLine = array_shift($lines) . "'" . ' . "\n"';
+                    $lastLine = "'" . array_pop($lines);
+                    $lines = array_map(function($s) { return "'" . $s . "'" . ' . "\n"'; }, $lines);
+                    array_unshift($lines, $firstLine);
+                    array_push($lines, $lastLine);
+                    $string = implode(" . \n", $lines);
+                }
+
+                return $string;
+
             default:
                 return var_export($var, true);
         }

--- a/tests/StarWarsIntrospectionTest.php
+++ b/tests/StarWarsIntrospectionTest.php
@@ -312,7 +312,7 @@ class StarWarsIntrospectionTest extends AbstractStarWarsTest
                             'args' => [
                                 [
                                     'defaultValue' =>  'null',
-                                    'description' => 'If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.',
+                                    'description' => "If omitted, returns the hero of the whole saga.\nIf provided, returns the hero of that particular episode.\n",
                                     'name' => 'episode',
                                     'type' => [
                                         'kind' => 'ENUM',

--- a/tests/starWarsSchema.yml
+++ b/tests/starWarsSchema.yml
@@ -143,7 +143,9 @@ Query:
                 args:
                     episode:
                         type: "Episode"
-                        description: "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode."
+                        description: |
+                          If omitted, returns the hero of the whole saga.
+                          If provided, returns the hero of that particular episode.
                 resolve: ["Overblog\\GraphQLGenerator\\Tests\\Resolver", "getHero"]
             human:
                 type: "Human"


### PR DESCRIPTION
## Reason for change

Multi-line strings get split by `AbstractClassGenerator::prefixCodeWithSpaces()` into separate lines and then each of these lines gets prefixed with spaces. This has the effect of inserting extra spaces into multi-line strings.

The specific area where this shows up is GraphQL schema element descriptions, which can be optionally formatted using Markdown syntax, and multiple spaces cause change of formatting.

## Fix description

For multi-line strings, instead of using a raw `var_export` result, split the string into separate lines and concatenate newline-containing strings separately.