### PR TITLE
Introduce differents generation mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
         - $HOME/.composer/cache
 
 before_install:
-    - if [[ "$TRAVIS_PHP_VERSION" != "7.1" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != "7.1" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
     - composer selfupdate
     - if [ "$GRAPHQLPHP_VERSION" != "" ]; then composer require "webonyx/graphql-php:${GRAPHQLPHP_VERSION}" --dev --no-update; fi;
 

--- a/src/Generator/AbstractClassGenerator.php
+++ b/src/Generator/AbstractClassGenerator.php
@@ -375,13 +375,22 @@ abstract class AbstractClassGenerator
     /**
      * Generates classes files.
      *
-     * @param array $configs raw configs
-     * @param string $outputDirectory
-     * @param bool $regenerateIfExists
+     * @param array    $configs raw configs
+     * @param string   $outputDirectory
+     * @param int|bool $mode
      *
      * @return array classes map [[FQCLN => classPath], [FQCLN => classPath], ...]
      */
-    abstract public function generateClasses(array $configs, $outputDirectory, $regenerateIfExists = false);
+    abstract public function generateClasses(array $configs, $outputDirectory, $mode = false);
 
-    abstract public function generateClass(array $config, $outputDirectory, $regenerateIfExists = false);
+    /**
+     * Generates a class file.
+     *
+     * @param array $config
+     * @param $outputDirectory
+     * @param bool $mode
+     *
+     * @return array classes map [FQCLN => classPath]
+     */
+    abstract public function generateClass(array $config, $outputDirectory, $mode = false);
 }

--- a/tests/AbstractStarWarsTest.php
+++ b/tests/AbstractStarWarsTest.php
@@ -49,4 +49,17 @@ abstract class AbstractStarWarsTest extends AbstractTypeGeneratorTest
         $expected = ['data' => $expected];
         $this->assertEquals($expected, $actual, json_encode($actual));
     }
+
+    protected function sortSchemaEntry(array &$entries, $entryKey, $sortBy)
+    {
+        if (isset($entries['data']['__schema'][$entryKey])) {
+            $data = &$entries['data']['__schema'][$entryKey];
+        } else {
+            $data = &$entries['__schema'][$entryKey];
+        }
+
+        usort($data, function ($data1, $data2) use ($sortBy) {
+            return strcmp($data1[$sortBy], $data2[$sortBy]);
+        });
+    }
 }

--- a/tests/StarWarsIntrospectionTest.php
+++ b/tests/StarWarsIntrospectionTest.php
@@ -11,6 +11,8 @@
 
 namespace Overblog\GraphQLGenerator\Tests;
 
+use GraphQL\GraphQL;
+
 class StarWarsIntrospectionTest extends AbstractStarWarsTest
 {
     // Star Wars Introspection Tests
@@ -53,7 +55,12 @@ class StarWarsIntrospectionTest extends AbstractStarWarsTest
                 ]
             ]
         ];
-        $this->assertValidQuery($query, $expected);
+
+        $actual = GraphQL::execute($this->schema, $query);
+        $this->sortSchemaEntry($actual, 'types', 'name');
+        $this->sortSchemaEntry($expected, 'types', 'name');
+        $expected = ['data' => $expected];
+        $this->assertEquals($expected, $actual, json_encode($actual));
     }
 
     // it('Allows querying the schema for query type')


### PR DESCRIPTION
Now the `generateClasses` and `generateClass` accepts bitmask to do more complex work when generating classes:

* **MODE_WRITE** create dirs and files only if not exists
* **MODE_OVERRIDE** allow to override file if existing
* **MODE_MAPPING_ONLY** returns the class mapping but nothing is generated
* **MODE_DRY_RUN** play all the generate process but no dir or file are actually created
* **true** is shortcut to `MODE_WRITE|MODE_OVERRIDE`
* **false** is shortcut to `MODE_WRITE` (**default**)