### PR TITLE
Remove chmod as it's giving warnings

### DIFF
--- a/src/Generator/AbstractTypeGenerator.php
+++ b/src/Generator/AbstractTypeGenerator.php
@@ -365,7 +365,6 @@ EOF;
                 }
                 if (($mode & self::MODE_OVERRIDE) || !file_exists($path)) {
                     file_put_contents($path, $code);
-                    chmod($path, 0664);
                 }
             }
         }


### PR DESCRIPTION
Also it's better to let the user control it them selves using `umask()`, removing the chmod will also make it compatible with windows.