### PR TITLE
Make created cache dir mask as option and default to 0777

### DIFF
--- a/src/Generator/AbstractTypeGenerator.php
+++ b/src/Generator/AbstractTypeGenerator.php
@@ -71,7 +71,7 @@ EOF;
      * @param string           $classNamespace The namespace to use for the classes.
      * @param string[]|string  $skeletonDirs
      */
-    public function __construct($classNamespace = self::DEFAULT_CLASS_NAMESPACE, $skeletonDirs = [], $cacheDirMask = 0777)
+    public function __construct($classNamespace = self::DEFAULT_CLASS_NAMESPACE, $skeletonDirs = [], $cacheDirMask = 0775)
     {
         parent::__construct($classNamespace, $skeletonDirs);
         $this->cacheDirMask = $cacheDirMask;

--- a/src/Generator/AbstractTypeGenerator.php
+++ b/src/Generator/AbstractTypeGenerator.php
@@ -63,12 +63,18 @@ EOF;
     private $expressionLanguage;
 
     /**
+     * @var int
+     */
+    protected $cacheDirMask;
+
+    /**
      * @param string           $classNamespace The namespace to use for the classes.
      * @param string[]|string  $skeletonDirs
      */
-    public function __construct($classNamespace = self::DEFAULT_CLASS_NAMESPACE, $skeletonDirs = [])
+    public function __construct($classNamespace = self::DEFAULT_CLASS_NAMESPACE, $skeletonDirs = [], $cacheDirMask = 0777)
     {
         parent::__construct($classNamespace, $skeletonDirs);
+        $this->cacheDirMask = $cacheDirMask;
     }
 
     public function setExpressionLanguage(ExpressionLanguage $expressionLanguage = null)
@@ -361,7 +367,7 @@ EOF;
             if ($mode & self::MODE_WRITE) {
                 $dir = dirname($path);
                 if (!is_dir($dir)) {
-                    mkdir($dir, 0775, true);
+                    mkdir($dir, $this->cacheDirMask, true);
                 }
                 if (($mode & self::MODE_OVERRIDE) || !file_exists($path)) {
                     file_put_contents($path, $code);


### PR DESCRIPTION
Make the created cache dir default to mask 0777 instead of 0775 to avoid permission errors on cache removal. Fix #24 