### PR TITLE
Order generated use statements

### DIFF
--- a/src/Generator/AbstractClassGenerator.php
+++ b/src/Generator/AbstractClassGenerator.php
@@ -335,7 +335,10 @@ abstract class AbstractClassGenerator
 
     protected function generateUseStatement(array $config)
     {
-        $useStatements = $this->tokenizeUseStatements(array_merge($this->internalUseStatements, $this->useStatements));
+        $statements = array_merge($this->internalUseStatements, $this->useStatements);
+        sort($statements);
+
+        $useStatements = $this->tokenizeUseStatements($statements);
 
         return $useStatements;
     }


### PR DESCRIPTION
Currently the use statements are not ordered and my other tools (IDE settings, coding style fixer etc.) don't like that.