### PR TITLE
Make ClassUtils work with PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /composer.lock
 /composer.phar
 /phpunit.xml
+/.phpunit.result.cache
 /.php_cs
 /.php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "overblog/graphql-php-generator",
     "type": "library",
     "description": "GraphQL types generator",
-    "keywords": ["GraphQL", "type", "generator"],
+    "keywords": [
+        "GraphQL",
+        "type",
+        "generator"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -10,7 +14,7 @@
             "homepage": "http://www.over-blog.com"
         }
     ],
-    "config" : {
+    "config": {
         "sort-packages": true,
         "bin-dir": "bin"
     },
@@ -20,7 +24,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.2",
+        "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.2 || ^9.0",
         "symfony/expression-language": "^3.4",
         "symfony/filesystem": "^3.4",
         "symfony/process": "^3.4",

--- a/src/ClassUtils.php
+++ b/src/ClassUtils.php
@@ -29,6 +29,10 @@ abstract class ClassUtils
 
     public static function shortenClassFromCode($code, callable $callback = null)
     {
+        if (null === $code) {
+            return null;
+        }
+
         if (null === $callback) {
             $callback = function ($matches) {
                 return static::shortenClassName($matches[1]);

--- a/tests/Generator/TypeGeneratorModeTest.php
+++ b/tests/Generator/TypeGeneratorModeTest.php
@@ -62,13 +62,17 @@ class TypeGeneratorModeTest extends TestCase
         $classes = $this->typeGenerator->generateClasses(self::CONFIG, $this->dir, $mode);
         $file = $this->dir.'/QueryType.php';
         $this->assertEquals(['Overblog\CG\GraphQLGenerator\__Schema__\QueryType' => $this->dir.'/QueryType.php'], $classes);
-        if (\method_exists($this, 'assertDirectoryNotExists')) {
+        if (\method_exists($this, 'assertDirectoryDoesNotExist')) {
+            $this->assertDirectoryDoesNotExist($this->dir);
+        } elseif (\method_exists($this, 'assertDirectoryNotExists')) {
             $this->assertDirectoryNotExists($this->dir);
         } else { // for phpunit 4
             $this->assertFalse(\file_exists($this->dir));
             $this->assertFalse(\is_dir($this->dir));
         }
-        if (\method_exists($this, 'assertFileNotExists')) {
+        if (\method_exists($this, 'assertFileDoesNotExist')) {
+            $this->assertFileDoesNotExist($file);
+        } elseif (\method_exists($this, 'assertFileNotExists')) {
             $this->assertFileNotExists($file);
         } else { // for phpunit 4
             $this->assertFalse(\file_exists($file));

--- a/tests/Generator/TypeGeneratorTest.php
+++ b/tests/Generator/TypeGeneratorTest.php
@@ -46,7 +46,11 @@ class TypeGeneratorTest extends AbstractTypeGeneratorTest
     public function testWrongGetSkeletonDirs(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Skeleton "fake" could not be found in .*\/skeleton./');
+        if (\method_exists($this, 'expectExceptionMessageMatches')) {
+            $this->expectExceptionMessageMatches('/Skeleton "fake" could not be found in .*\/skeleton./');
+        } else {
+            $this->expectExceptionMessageRegExp('/Skeleton "fake" could not be found in .*\/skeleton./');
+        }
         $this->typeGenerator->getSkeletonContent('fake');
     }
 


### PR DESCRIPTION
PHP 8.0 has stricter typing: `preg_replace_callback(): Argument #3 ($subject) must be of type array|string, null given`

Also make this library testable with PHP 8.0, which requires a newer version of phpunit